### PR TITLE
[feat] board event 작성 및 수정, board uid 연동 방식 구현

### DIFF
--- a/board/models.py
+++ b/board/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from booth.models import Booth
+from adminuser.models import Admin
 
 # Create your models here.
 from polymorphic.models import PolymorphicModel
@@ -15,6 +16,7 @@ class Board(PolymorphicModel):
         choices=Category.choices,
         default=Category.NOTICE
     )
+    writer = models.CharField(max_length=50, blank=True, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -32,7 +34,7 @@ class Notice(Board):
 
 #분실물
 def image_upload_path(instance, filename):
-  return f'board_images/{instance.pk}/{filename}'
+    return f'board_images/{instance.pk}/{filename}'
 
 class Lost(Board):
     title = models.CharField(max_length=200)
@@ -49,8 +51,8 @@ class BoothEvent(Board):
     title = models.CharField(max_length=50)
     detail = models.TextField()
     booth = models.ForeignKey(Booth, on_delete=models.CASCADE) 
-    start_time = models.DateField()
-    end_time = models.DateField()
+    start_time = models.DateTimeField()
+    end_time = models.DateTimeField()
     
     def save(self, *args, **kwargs):
         self.category = Board.Category.EVENT

--- a/board/serializers.py
+++ b/board/serializers.py
@@ -1,20 +1,29 @@
 from rest_framework import serializers
 from drf_polymorphic.serializers import PolymorphicSerializer
+
+
 from .models import *
 
 class BoardSerializer(serializers.ModelSerializer):
-    writer = serializers.SerializerMethodField()
-
     class Meta:
         model = Board
-        fields = ['id', 'category', 'writer']
-        read_only_fields = ['id', 'created_at', 'updated_at']
+        fields = ['id', 'category', 'writer', 'created_at', 'updated_at']
     
-    # 구현 필요! uid와 비교하여 adminuser 이름 넣어주기
     def get_writer(self, obj):
-        if hasattr(obj, "adminuser") and obj.adminuser:
-            return obj.adminuser.name
-        return None
+        request = self.context.get("request")
+        if not request:
+            return None
+
+        # token 가져오기 (POST/PUT -> data, GET -> query_params)
+        token = request.data.get("token") or request.query_params.get("token")
+        if not token:
+            return None
+
+        try:
+            admin = Admin.objects.get(code=token)
+            return admin.name
+        except Admin.DoesNotExist:
+            return None
 
 class NoticeSerializer(BoardSerializer):
     class Meta(BoardSerializer.Meta):
@@ -58,17 +67,23 @@ class BoardListSerializer(serializers.Serializer):
         data.pop("polymorphic_ctype", None)
         return data
 
-class BoothEventSerializer(serializers.ModelSerializer):
+class BoothEventSerializer(BoardSerializer):
     booth_id = serializers.IntegerField(source='booth.id', read_only=True)
     booth_name = serializers.CharField(source='booth.admin.name', read_only=True)
     category = serializers.CharField(source='category', read_only=True)
 
     class Meta:
         model = BoothEvent
-        fields = ['id', 'category','booth_id', 
+        fields = BoardSerializer.Meta.fields +['booth_id', 
                     'booth_name','title', 'detail', 
-                    'start_time', 'end_time',
-                    'created_at', 'updated_at']
+                    'start_time', 'end_time']
 
     def create(self, validated_data):
         return BoothEvent.objects.create(**validated_data)
+    
+class BoardPolymorphicSerializer(PolymorphicSerializer):
+    model_serializer_mapping = {
+        Notice: NoticeSerializer,
+        Lost: LostSerializer,
+        BoothEvent: BoothEventSerializer,
+    }

--- a/board/services.py
+++ b/board/services.py
@@ -1,11 +1,14 @@
-# CRUD 중 C, R, U에 해당하는 비즈니스 로직
-from django.shortcuts import render
-from rest_framework import viewsets, status
-from rest_framework.response import Response
-from rest_framework.permissions import AllowAny
+from adminuser.models import Admin
 
-from .models import *
-from .serializers import *
-
-# @action(detail=False, methods=["GET"])
-#   def related(self, request):
+def get_writer_from_uid(uid: str) -> str | None:
+    """
+    UID(code)로 Admin 조회 후 name 반환.
+    유효하지 않으면 None 반환.
+    """
+    if not uid:
+        return None
+    try:
+        admin = Admin.objects.get(code=uid)
+        return admin.name
+    except Admin.DoesNotExist:
+        return None


### PR DESCRIPTION
### 📑 이슈 번호

- close #15 

### ✨️ 작업 내용
- board event 작성 및 수정 (booth 연동 및 is_event 필드 활성화)
- board writer 필드 추가
- board uid 연동 방식 구현
- uid 연동 확인 후 adminuser 모델에서 name 가져와 writer 에 저장

### 💭 코멘트


### 📸 구현 결과
