### PR TITLE
[Fix] queryset 권한 구분, 긴급공지 content 필드 추가

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -17,6 +17,29 @@ class BoardViewSet(viewsets.ModelViewSet):
     queryset = Board.objects.all().order_by("-created_at")
     serializer_class = BoardPolymorphicSerializer
 
+    def get_queryset(self):
+        user = self.request.user # 로그인 여부 확인
+        uid = self.request.data.get("uid")
+
+        # 1. 로그인 안 한 경우 → 전체 공개
+        if not user.is_authenticated:
+            return Board.objects.all().order_by("-created_at")
+        
+        # 2. 로그인 한 경우 → Admin 매핑 확인
+        if not uid:
+            return Board.objects.none()
+        admin = resolve_admin_by_uid(uid)
+        if not admin:
+            return Board.objects.none()
+
+        # 2-1. 총학생회 → 전체 글
+        if admin.role == "Staff":
+            return Board.objects.all().order_by("-created_at")
+
+        # 2-2. 동아리/학과 → 본인 글만
+        return Board.objects.filter(writer=admin.name).order_by("-created_at")
+
+
     def get_serializer_class(self):
         if self.action == "list":
             # 리스트 조회용
@@ -58,6 +81,7 @@ class BoardViewSet(viewsets.ModelViewSet):
                 "message": message,
                 "board_id": board.id,
                 "board_title": board.title,
+                "board_title": board.content,
         })
     
     def destroy(self, request, *args, **kwargs):

--- a/board/views.py
+++ b/board/views.py
@@ -81,7 +81,7 @@ class BoardViewSet(viewsets.ModelViewSet):
                 "message": message,
                 "board_id": board.id,
                 "board_title": board.title,
-                "board_title": board.content,
+                "board_content": board.content,
         })
     
     def destroy(self, request, *args, **kwargs):


### PR DESCRIPTION
### 📑 이슈 번호

- close #73

### ✨️ 작업 내용

- queryset 을 로그인 유무에 따라 권한 분리 하엿씁니다
- 긴급공지 수정시 content를 추가 반환하도록 했습니다!

### 📸 구현 결과
<img width="771" height="604" alt="image" src="https://github.com/user-attachments/assets/1f240089-5a6c-4b5c-b72e-ca9e26ab3b0c" />