### PR TITLE
[Fix] redis 캐시 설정

### DIFF
--- a/docker-compose.redis.yml
+++ b/docker-compose.redis.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+
+services:
+  redis:
+    image: redis:7
+    container_name: local_redis
+    ports:
+      - "6379:6379"
+    restart: unless-stopped

--- a/project/settings.py
+++ b/project/settings.py
@@ -213,12 +213,26 @@ CORS_ALLOWED_ORIGINS = [
 
 # 캐시 설정 추가 (UID -> admin_id 매핑 저장. 개발은 LocMem, 배포는 Redis)
 
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "unique-admin-cache",
+USE_REDIS = os.getenv("USE_REDIS", "false").lower() == "true"
+
+if USE_REDIS:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": "redis://127.0.0.1:6379/1",
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            }
+        }
     }
-}
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "unique-admin-cache",
+        }
+    }
+
 
 # UID 만료 시간 (초) - 1시간
 ADMIN_UID_TTL = 3600

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-cors-headers==4.8.0
 django-environ==0.12.0
 django-filter==25.1
 django-polymorphic==4.1.0
+django-redis==6.0.0
 django-storages==1.14.6
 djangorestframework==3.16.1
 djangorestframework_simplejwt==5.5.1
@@ -51,6 +52,7 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 pytz==2025.2
 PyYAML==6.0.2
+redis==6.4.0
 referencing==0.36.2
 requests==2.32.5
 rpds-py==0.27.1


### PR DESCRIPTION
### 📑 이슈 번호

- close #73

### ✨️ 작업 내용
- settings.py 로컬은 LocMem, 배포는 Redis로 분기처리
- env 파일에 USE_REDIS=true 혹은 false로 사용

- 배포서버에서는 apt install redis-server 설치 필요합니다!

### 📸 구현 결과
- 게시물 두 번째 등록 시 에러 없이 한 번에 등록된 화면
<img width="859" height="611" alt="스크린샷 2025-09-20 140752" src="https://github.com/user-attachments/assets/9c2e6a1e-cd0a-4913-a505-bd2ef9adc9ed" />
- Redis 실행 중인지 체크 화면
<img width="402" height="165" alt="스크린샷 2025-09-20 140859" src="https://github.com/user-attachments/assets/728b4b24-c646-4939-a7eb-6b0572e21cb3" />