### PR TITLE
[Fix] 관리자 페이지 긴급공지 제외하고 게시물 GET하도록 수정

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -150,6 +150,7 @@ class NoticeViewSet(viewsets.ModelViewSet):
 class LostViewSet(viewsets.ModelViewSet):
     queryset = Lost.objects.all().order_by("-created_at")
     serializer_class = LostSerializer
+    permission_classes = [AllowAny]
 
     def create(self, request, *args, **kwargs):
         uid = request.data.get("uid")

--- a/board/views.py
+++ b/board/views.py
@@ -15,6 +15,7 @@ from adminuser.services import resolve_admin_by_uid
 # POST /board/notices 또는 losts
 # PATCH, GET /board/{id}
 class BoardViewSet(viewsets.ModelViewSet):
+    permission_classes = [AllowAny]
     queryset = Board.objects.all().order_by("-created_at")
     serializer_class = BoardPolymorphicSerializer
 
@@ -25,7 +26,14 @@ class BoardViewSet(viewsets.ModelViewSet):
             return Board.objects.all().order_by("-created_at")
 
         # 본인 글만 보이도록
-        return Board.objects.filter(writer=admin.name).order_by("-created_at")
+        qs = Board.objects.filter(writer=admin.name)
+
+        # Staff, Stuco는 긴급공지 제외
+        if admin.role in ["Staff", "Stuco"]:
+            notice_ids = Notice.objects.filter(is_emergency=True).values_list("id", flat=True)
+            qs = qs.exclude(id__in=notice_ids)
+
+        return qs.order_by("-created_at")
 
 
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -132,6 +132,8 @@ AUTH_PASSWORD_VALIDATORS = [
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
+        # UID 인증이 최상단에서 작동되어야 함.
+        "adminuser.authentication.UIDAuthentication", # 커스텀 인증 추가
         #"common.authentication.CookieJwtAuthentication",
         "rest_framework_simplejwt.authentication.JWTAuthentication",
     ),


### PR DESCRIPTION
### 📑 이슈 번호

- close #73

### ✨️ 작업 내용
- 관리자 페이지 board GET에서 긴급공지 제외하고 불러오도록 수정

