### PR TITLE
🐛Fix: related 관련 게시글에서 긴급공지 제거 (#121)

### DIFF
--- a/board/views.py
+++ b/board/views.py
@@ -102,9 +102,11 @@ class BoardViewSet(viewsets.ModelViewSet):
 
         related = (
             Board.objects.filter(created_at__lt=created_at)
+            .exclude(
+                id__in=Notice.objects.filter(is_emergency=True).values_list("board_ptr_id", flat=True)
+            )
             .order_by("-created_at")[:3]
         )
-
         serializer = BoardListSerializer(related, many=True)
         return Response({
             "message": "관련 게시글 조회에 성공하였습니다.",


### PR DESCRIPTION
### 📑 이슈 번호

- close #

### ✨️ 작업 내용
관련 게시글에서 긴급공지 제거

### 📸 구현 결과
코드 반영 전
<img width="734" height="916" alt="스크린샷 2025-09-23 164704" src="https://github.com/user-attachments/assets/62a5682a-084a-4620-8aa4-b8fdd765afa2" />

반영 후
<img width="638" height="886" alt="스크린샷 2025-09-23 164733" src="https://github.com/user-attachments/assets/36c72390-dc1a-47c2-9522-00647b714033" />
